### PR TITLE
Remove deprecated usage of File.exists?

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,7 @@ jobs:
     strategy:
       matrix:
         combo:
+          - ruby: "3.2"
           - ruby: "3.1"
           - ruby: "3.0"
           - ruby: "2.7"

--- a/lib/erb/formatter/ignore_list.rb
+++ b/lib/erb/formatter/ignore_list.rb
@@ -1,7 +1,7 @@
 class ERB::Formatter::IgnoreList
   def initialize(contents: nil, base_dir: Dir.pwd)
     ignore_list_path = "#{base_dir}/.format-erb-ignore"
-    @contents = contents || (File.exists?(ignore_list_path) ? File.read(ignore_list_path) : '')
+    @contents = contents || (File.exist?(ignore_list_path) ? File.read(ignore_list_path) : '')
     @ignore_list = @contents.lines
   end
 
@@ -12,4 +12,3 @@ class ERB::Formatter::IgnoreList
     end
   end
 end
-


### PR DESCRIPTION
`File.exists?` is deprecated in [the latest release of Ruby](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/) (3.2.0).  I encountered the issue when I upgraded to Ruby 3.2.0 so I expect more people to run into the same issue as they upgrade.