### PR TITLE
Use syntax-tree-erb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,6 @@ gemspec
 gem "rake", "~> 13.0"
 
 gem "minitest", "~> 5.0"
+
+# Dir['test/fixtures/*.expected.erb'].each { File.write _1, SyntaxTree::ERB.format(File.read(p _1.sub('.expected', ''))) rescue puts $! }
+gem "w_syntax_tree-erb", "~> 0.9.5"

--- a/test/fixtures/case_when.html.expected.erb
+++ b/test/fixtures/case_when.html.expected.erb
@@ -1,10 +1,18 @@
-<% case 'fake' %>
-<% when 'fake' %>
-  <span>there</span>
-<% when 'something' %>
-  <span>there</span>
-<% when 'else' %>
-  <span>hi</span>
+<% case "fake" %>
+<% when "fake" %>
+  <span>
+    there
+  </span>
+<% when "something" %>
+  <span>
+    there
+  </span>
+<% when "else" %>
+  <span>
+    hi
+  </span>
 <% else %>
-  <span>there</span>
+  <span>
+    there
+  </span>
 <% end %>

--- a/test/fixtures/comments-2.html.expected.erb
+++ b/test/fixtures/comments-2.html.expected.erb
@@ -1,7 +1,7 @@
 <%# link_to 'Approve', some_path, class: 'something', disabled: disabled %>
 <%#= link_to 'Approve', some_path, class: 'something', disabled: disabled %>
 <%#- link_to 'Approve', some_path, class: 'something', disabled: disabled %>
-<%-# link_to 'Approve', some_path, class: 'something', disabled: disabled %>
+<%- # link_to 'Approve', some_path, class: 'something', disabled: disabled %>
 
 <%# if smth %>
 <%#else %>

--- a/test/fixtures/comments.html.expected.erb
+++ b/test/fixtures/comments.html.expected.erb
@@ -1,64 +1,86 @@
-<%#
-This fails
-hey
-hey
-hey
-hey %>
+<%
+  #
+  This fails
+  hey
+  hey
+  hey
+  hey
+%>
 
-<%#
-This fails
-hey
-hey
-hey
-hey %>
+<%
+  #
+  This fails
+  hey
+  hey
+  hey
+  hey
+%>
 
-<%#
-This fails
-hey
-hey
-hey
-hey %>
+<%
+  #
+  This fails
+  hey
+  hey
+  hey
+  hey
+%>
 
-<%# This fails
-This fails
-hey
-hey
-hey
-hey %>
+<%
+  # This fails
+  This fails
+  hey
+  hey
+  hey
+  hey
+%>
 
-<%# This fails
-This fails
-hey
-hey
-hey
-hey %>
+<%
+  # This fails
+  This fails
+  hey
+  hey
+  hey
+  hey
+%>
 
-<%# This fails
-This fails
-hey
-hey
-hey
-hey %>
+<%
+  # This fails
+  This fails
+  hey
+  hey
+  hey
+  hey
+%>
 
-<%#This fails
-This fails
-hey
-hey
-hey
-hey %>
+<%
+  #This fails
+  This fails
+  hey
+  hey
+  hey
+  hey
+%>
 
-<%#    This fails
-This fails
-hey
-hey
-hey
-hey %>
+<%
+  #    This fails
+  This fails
+  hey
+  hey
+  hey
+  hey
+%>
 
-<%#
-hey %>
+<%
+  #
+  hey
+%>
 
-<%#
-hey %>
+<%
+  #
+  hey
+%>
 
-<%#
-hey %>
+<%
+  #
+  hey
+%>

--- a/test/fixtures/complex_case_when.html.expected.erb
+++ b/test/fixtures/complex_case_when.html.expected.erb
@@ -1,18 +1,25 @@
 <div>
   <% if payment_method.present? %>
     <% case payment_method.class.to_s %>
-    <% when 'Foo::PaymentMethod::FooCreditCard' %>
+    <% when "Foo::PaymentMethod::FooCreditCard" %>
       <% if payment_method.active %>
         <span class="card-icon <%= payment_source.cc_type %>"></span>
-        *<%= payment_source.last_digits %>
-        <%= payment_source.month %>/<%= payment_source.year %>
+        *
+        <%= payment_source.last_digits %>
+        <%= payment_source.month %>
+        /
+        <%= payment_source.year %>
       <% else %>
         <%= t(".payment.card_removed_or_expired") %>
       <% end %>
-    <% when 'Foo::PaymentMethod::Bar' %>
-      <span><%= t(".payment.invoice") %></span>
-    <% when 'Foo::PaymentMethod' %>
-      <span><%= t(".payment.stripe_invoice") %></span>
+    <% when "Foo::PaymentMethod::Bar" %>
+      <span>
+        <%= t(".payment.invoice") %>
+      </span>
+    <% when "Foo::PaymentMethod" %>
+      <span>
+        <%= t(".payment.stripe_invoice") %>
+      </span>
     <% else %>
       <% Rails.logger.error.report(
         StandardError.new(

--- a/test/fixtures/empty-text-between-erb.html.expected.erb
+++ b/test/fixtures/empty-text-between-erb.html.expected.erb
@@ -1,3 +1,4 @@
 <%= render Component.new do %>
   ·
-  <%= link_to "foo", bar_path %><% end %>
+  <%= link_to "foo", bar_path %>
+<% end %>

--- a/test/fixtures/formatted.html.expected.erb
+++ b/test/fixtures/formatted.html.expected.erb
@@ -1,6 +1,6 @@
 <% link_to "Very long string here and there",
-very_very_very_long_long_long_pathhhhhh_here,
-opt: "212",
-options: "222sdasdasd",
-class: "  322 ",
-dis: diss %>
+        very_very_very_long_long_long_pathhhhhh_here,
+        opt: "212",
+        options: "222sdasdasd",
+        class: "  322 ",
+        dis: diss %>

--- a/test/fixtures/front-matter.html.expected.erb
+++ b/test/fixtures/front-matter.html.expected.erb
@@ -6,7 +6,6 @@ Baz: |
   foo-bar
   foo bar
 ---
-
 <body class="h-full">
   <% flash.each do |type, data| %>
     <%= render AlertComponent.new(type: type, data: data) %>

--- a/test/fixtures/long_deep_nested.html.expected.erb
+++ b/test/fixtures/long_deep_nested.html.expected.erb
@@ -17,11 +17,11 @@
                                 <div>
                                   <div>
                                     <% link_to "Very long long long long long long long long string here and there",
-                                    very_very_very_long_long_long_pathhhhhh_here,
-                                    opt: "212",
-                                    options: "222sdasdasd",
-                                    class: "  322 ",
-                                    dis: diss %>
+                                            very_very_very_long_long_long_pathhhhhh_here,
+                                            opt: "212",
+                                            options: "222sdasdasd",
+                                            class: "  322 ",
+                                            dis: diss %>
 
                                     <% link_to "string", path, opt: "212", options: "222sdasdasd" %>
 

--- a/test/fixtures/single-2.html.expected.erb
+++ b/test/fixtures/single-2.html.expected.erb
@@ -1,1 +1,3 @@
+
 <%= link_to "New Order", class: "btn btn-success" %>
+

--- a/test/fixtures/single.html.expected.erb
+++ b/test/fixtures/single.html.expected.erb
@@ -1,1 +1,3 @@
+
 <%= link_to "New Order", new_order_path, class: "btn btn-success" %>
+

--- a/test/fixtures/with_block.html.expected.erb
+++ b/test/fixtures/with_block.html.expected.erb
@@ -1,3 +1,5 @@
-<% foo.each do |bar| %>
-  <p><%= baz %></p>
+<% foo.each do |bar|%>
+  <p>
+    <%= baz %>
+  </p>
 <% end %>


### PR DESCRIPTION
Consider joining forces with https://github.com/davidwessman/syntax_tree-erb as the project has done an awesome job already and with a few fixes we could get feature parity.

Currently trying to run it on existing fixtures has the following issues:

- "test/fixtures/if_then_else.html.erb" → `Found no matching erb-tag to the if-tag at line 6, char 208..351`
- Comment ERB tags are rendered with a space before the `#` char, might be intentional tho
- Whitespace is not preserved between HTML tags: adding newlines around `Foo` in `<span>Foo</span>` can disrupt how the HTML is rendered
- Whitespace is not preserved between ERB tags: adding newlines inside `%><%=` in `<%= "Foo" %><%= "Bar" %>` can disrupt how the HTML is rendered

cc @davidwessman the pretty print based approach of SyntaxTree is far superior to the long formatting script in this project, I thought was good to let you know I'm considering switching to it entirely in case you're interested in helping out 🙌 