### PR TITLE
Break class attributes at line width instead of using one class per line

### DIFF
--- a/lib/erb/formatter/command_line.rb
+++ b/lib/erb/formatter/command_line.rb
@@ -10,7 +10,7 @@ class ERB::Formatter::CommandLine
     @argv = argv.dup
     @stdin = stdin
 
-    @write, @filename, @read_stdin, @code = nil
+    @write, @filename, @read_stdin, @code, @single_class_per_line = nil
 
     OptionParser.new do |parser|
       parser.banner = "Usage: #{$0} FILENAME... --write"
@@ -35,6 +35,10 @@ class ERB::Formatter::CommandLine
 
       parser.on("--print-width WIDTH", Integer, "Set the formatted output width") do |value|
         @width = value
+      end
+
+      parser.on("--single-class-per-line", "Print each class on a separate line") do |value|
+        @single_class_per_line = value
       end
 
       parser.on("--[no-]debug", "Enable debug mode") do |value|
@@ -77,7 +81,7 @@ class ERB::Formatter::CommandLine
       if ignore_list.should_ignore_file? filename
         print code unless write
       else
-        html = ERB::Formatter.new(code, filename: filename, line_width: @width || 80)
+        html = ERB::Formatter.new(code, filename: filename, line_width: @width || 80, single_class_per_line: @single_class_per_line)
 
         if write
           File.write(filename, html)

--- a/test/fixtures/multiline_attributes.html.erb
+++ b/test/fixtures/multiline_attributes.html.erb
@@ -1,0 +1,3 @@
+<button class="text-gray-700 bg-transparent hover:bg-gray-50 active:bg-gray-100 focus:bg-gray-50 focus:ring-gray-300 focus:ring-2
+disabled:text-gray-300 disabled:bg-transparent disabled:border-gray-300 disabled:cursor-not-allowed
+aria-disabled:text-gray-300 aria-disabled:bg-transparent aria-disabled:border-gray-300 aria-disabled:cursor-not-allowed">Button</button>

--- a/test/fixtures/multiline_attributes.html.expected.erb
+++ b/test/fixtures/multiline_attributes.html.expected.erb
@@ -1,0 +1,9 @@
+<button
+  class="
+    text-gray-700 bg-transparent hover:bg-gray-50 active:bg-gray-100
+    focus:bg-gray-50 focus:ring-gray-300 focus:ring-2 disabled:text-gray-300
+    disabled:bg-transparent disabled:border-gray-300 disabled:cursor-not-allowed
+    aria-disabled:text-gray-300 aria-disabled:bg-transparent
+    aria-disabled:border-gray-300 aria-disabled:cursor-not-allowed
+  "
+>Button</button>


### PR DESCRIPTION
_Thanks to @Azeem838 for the pairing session on this feature 🙏_

```
erb-formatter:elia+azeem/single-class-per-line ⤑ be exe/erb-format test/fixtures/multiline_attributes.html.erb                                                                                   ~/C/N/erb-formatter
<button
  class="
    text-gray-700 bg-transparent hover:bg-gray-50 active:bg-gray-100
    focus:bg-gray-50 focus:ring-gray-300 focus:ring-2 disabled:text-gray-300
    disabled:bg-transparent disabled:border-gray-300 disabled:cursor-not-allowed
    aria-disabled:text-gray-300 aria-disabled:bg-transparent
    aria-disabled:border-gray-300 aria-disabled:cursor-not-allowed
  "
>Button</button>
erb-formatter:elia+azeem/single-class-per-line ⤑ be exe/erb-format test/fixtures/multiline_attributes.html.erb --single-class-per-line                                                           ~/C/N/erb-formatter
<button
  class="
    text-gray-700
    bg-transparent
    hover:bg-gray-50
    active:bg-gray-100
    focus:bg-gray-50
    focus:ring-gray-300
    focus:ring-2
    disabled:text-gray-300
    disabled:bg-transparent
    disabled:border-gray-300
    disabled:cursor-not-allowed
    aria-disabled:text-gray-300
    aria-disabled:bg-transparent
    aria-disabled:border-gray-300
    aria-disabled:cursor-not-allowed
  "
>Button</button>
erb-formatter:elia+azeem/single-class-per-line ⤑                                                                                                                                                 ~/C/N/erb-formatter
```