### PR TITLE
Strip and rebuild newlines from inside class attributes

### DIFF
--- a/lib/erb/formatter.rb
+++ b/lib/erb/formatter.rb
@@ -124,14 +124,20 @@ class ERB::Formatter
 
     attrs.scan(ATTR).flatten.each do |attr|
       attr.strip!
-      full_attr = indented(attr)
       name, value = attr.split('=', 2)
+
+      if value.nil?
+        attr_html << indented("#{name}")
+        next
+      end
+
+      value_parts = value[1...-1].strip.split(/\s+/)
+
+      full_attr = indented("#{name}=#{value[0]}#{value_parts.join(" ")}#{value[-1]}")
 
       if full_attr.size > line_width && MULTILINE_ATTR_NAMES.include?(name) && attr.match?(QUOTED_ATTR)
         attr_html << indented("#{name}=#{value[0]}")
         tag_stack_push('attr"', value)
-
-        value_parts = value[1...-1].strip.split(/\s+/)
 
         if !@single_class_per_line && name == 'class'
           line = value_parts.shift

--- a/test/fixtures/multiline_attributes.html.erb
+++ b/test/fixtures/multiline_attributes.html.erb
@@ -1,3 +1,6 @@
 <button class="text-gray-700 bg-transparent hover:bg-gray-50 active:bg-gray-100 focus:bg-gray-50 focus:ring-gray-300 focus:ring-2
 disabled:text-gray-300 disabled:bg-transparent disabled:border-gray-300 disabled:cursor-not-allowed
 aria-disabled:text-gray-300 aria-disabled:bg-transparent aria-disabled:border-gray-300 aria-disabled:cursor-not-allowed">Button</button>
+
+<nav class="
+flex flex-col bg-gray-15 p-4 w-full       " data-controller="<%= stimulus_id %>" data-<%= stimulus_id %>-cookie-value="solidus_admin"> Foooo </nav>

--- a/test/fixtures/multiline_attributes.html.expected.erb
+++ b/test/fixtures/multiline_attributes.html.expected.erb
@@ -7,3 +7,11 @@
     aria-disabled:border-gray-300 aria-disabled:cursor-not-allowed
   "
 >Button</button>
+
+<nav
+  class="flex flex-col bg-gray-15 p-4 w-full"
+  data-controller="<%= stimulus_id %>"
+  data-<%= stimulus_id %>-cookie-value="solidus_admin"
+>
+  Foooo
+</nav>


### PR DESCRIPTION
A newline inside a class attribute was preserved with weird results.