### PR TITLE
Use trailing commas

### DIFF
--- a/lib/erb/formatter.rb
+++ b/lib/erb/formatter.rb
@@ -9,6 +9,7 @@ require 'securerandom'
 require 'erb/formatter/version'
 
 require 'syntax_tree'
+require 'syntax_tree/plugin/trailing_comma'
 
 class ERB::Formatter
   module SyntaxTreeCommandPatch

--- a/test/erb/test_formatter.rb
+++ b/test/erb/test_formatter.rb
@@ -128,7 +128,7 @@ class ERB::TestFormatter < Minitest::Test
       "<div>\n" \
       "  <%= render MyComponent.new(\n" \
       "    foo: barbarbarbarbarbarbarbar,\n" \
-      "    bar: bazbazbazbazbazbazbazbaz\n" \
+      "    bar: bazbazbazbazbazbazbazbaz,\n" \
       "  ) %>\n" \
       "</div>\n",
       ERB::Formatter.format("<div> <%=render MyComponent.new(foo:barbarbarbarbarbarbarbar,bar:bazbazbazbazbazbazbazbaz)%> </div>"),

--- a/test/fixtures/complex_case_when.html.expected.erb
+++ b/test/fixtures/complex_case_when.html.expected.erb
@@ -16,8 +16,8 @@
     <% else %>
       <% Rails.logger.error.report(
         StandardError.new(
-          "No human readable name found for payment method #{payment_method.class}"
-        )
+          "No human readable name found for payment method #{payment_method.class}",
+        ),
       ) %>
     <% end %>
   <% else %>

--- a/test/fixtures/formatted-2.html.expected.erb
+++ b/test/fixtures/formatted-2.html.expected.erb
@@ -10,7 +10,7 @@
     { greeting: "Hello from react-rails." },
     { greeting: "Hello from react-rails." },
     { greeting: "Hello from react-rails." },
-    { greeting: "Hello from react-rails." }
+    { greeting: "Hello from react-rails." },
   ) %>
 
 </div>

--- a/test/fixtures/long_deep_nested-2.html.expected.erb
+++ b/test/fixtures/long_deep_nested-2.html.expected.erb
@@ -20,14 +20,14 @@
                                       "HelloWorld",
                                       {
                                         greeting:
-                                          "Hello from react-rails react-rails react-rails react-rails react-rails react-rails react-rails."
+                                          "Hello from react-rails react-rails react-rails react-rails react-rails react-rails react-rails.",
                                       },
                                       {
                                         greeting:
-                                          "Hello from react-rails react-rails react-rails react-rails react-rails react-rails react-rails."
+                                          "Hello from react-rails react-rails react-rails react-rails react-rails react-rails react-rails.",
                                       },
                                       { greeting: "Hello from react-rails." },
-                                      { greeting: "Hello from react-rails." }
+                                      { greeting: "Hello from react-rails." },
                                     ) %>
                                   </div>
                                 </div>

--- a/test/fixtures/trailing_comma.html.erb
+++ b/test/fixtures/trailing_comma.html.erb
@@ -1,0 +1,6 @@
+<%= render component("ui/table").new(
+    id: "option-types-list",
+    data: {
+      rows: @option_types,url: ->(option_type) { edit_admin_option_type_path(option_type) },columns: columns,batch_actions: batch_actions,
+      },
+      ) %>

--- a/test/fixtures/trailing_comma.html.expected.erb
+++ b/test/fixtures/trailing_comma.html.expected.erb
@@ -1,0 +1,9 @@
+<%= render component("ui/table").new(
+  id: "option-types-list",
+  data: {
+    rows: @option_types,
+    url: ->(option_type) { edit_admin_option_type_path(option_type) },
+    columns: columns,
+    batch_actions: batch_actions,
+  },
+) %>


### PR DESCRIPTION
Reduce the roundtrip time for adding a line to a list of arguments or reordering them and discovering about the missing comma after a refresh of the browser.