### PR TITLE
Use Prism to check code in Ruby 3.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,7 @@ jobs:
     strategy:
       matrix:
         combo:
+          - ruby: "3.3"
           - ruby: "3.2"
           - ruby: "3.1"
           - ruby: "3.0"

--- a/lib/erb/formatter.rb
+++ b/lib/erb/formatter.rb
@@ -48,10 +48,17 @@ class ERB::Formatter
 
   SELF_CLOSING_TAG = /\A(area|base|br|col|command|embed|hr|img|input|keygen|link|menuitem|meta|param|source|track|wbr)\z/i
 
-  RUBY_OPEN_BLOCK = ->(code) do
-    # is nil when the parsing is broken, meaning it's an open expression
-    Ripper.sexp(code).nil?
-  end.freeze
+  begin
+    require 'prism' # ruby 3.3
+    RUBY_OPEN_BLOCK = Prism.method(:parse_failure?)
+  rescue LoadError
+    require 'ripper'
+    RUBY_OPEN_BLOCK = ->(code) do
+      # is nil when the parsing is broken, meaning it's an open expression
+      Ripper.sexp(code).nil?
+    end.freeze
+  end
+
   RUBY_CLOSE_BLOCK = /\Aend\z/
   RUBY_REOPEN_BLOCK = /\A(else|elsif\b(.*)|when\b(.*))\z/
 


### PR DESCRIPTION
Ripper behavior is different in Ruby 3.3.