### PR TITLE
Format unquotted attributes

### DIFF
--- a/lib/erb/formatter.rb
+++ b/lib/erb/formatter.rb
@@ -136,6 +136,10 @@ class ERB::Formatter
     attrs.scan(ATTR).flatten.each do |attr|
       attr.strip!
       name, value = attr.split('=', 2)
+      if UNQUOTED_ATTR =~ attr
+        attr_html << indented("#{name}=\"#{value}\"")
+        next
+      end
 
       if value.nil?
         attr_html << indented("#{name}")

--- a/test/fixtures/attributes.html.erb
+++ b/test/fixtures/attributes.html.erb
@@ -1,0 +1,8 @@
+<img src="image.jpg" alt="Responsive Image"
+     srcset="image-480w.jpg 480w,
+             image-800w.jpg 800w,
+             image-1200w.jpg 1200w"
+     sizes="(max-width: 600px) 480px,
+            (max-width: 1000px) 800px,
+            1200px"
+     data-autocomplete-min-length-value=2>

--- a/test/fixtures/attributes.html.expected.erb
+++ b/test/fixtures/attributes.html.expected.erb
@@ -1,0 +1,7 @@
+<img
+  src="image.jpg"
+  alt="Responsive Image"
+  srcset="image-480w.jpg 480w, image-800w.jpg 800w, image-1200w.jpg 1200w"
+  sizes="(max-width: 600px) 480px, (max-width: 1000px) 800px, 1200px"
+  data-autocomplete-min-length-value="2"
+>


### PR DESCRIPTION
It looks reasonable to skip them as they should not need any transformations.

Fix #40