### PR TITLE
Add a --fail-level check CLI option

### DIFF
--- a/lib/erb/formatter/command_line.rb
+++ b/lib/erb/formatter/command_line.rb
@@ -62,6 +62,10 @@ class ERB::Formatter::CommandLine
         $DEBUG = value
       end
 
+      parser.on("--fail-level LEVEL", "'check' exits(1) on any formatting changes)") do |value|
+        @fail_level = value
+      end
+
       parser.on("-h", "--help", "Prints this help") do
         puts parser
         exit
@@ -94,6 +98,8 @@ class ERB::Formatter::CommandLine
       css_class_sorter = self.class.tailwindcss_class_sorter(@tailwind_output_path)
     end
 
+    files_changed = false
+
     files.each do |(filename, code)|
       if ignore_list.should_ignore_file? filename
         print code unless write
@@ -106,6 +112,8 @@ class ERB::Formatter::CommandLine
           css_class_sorter: css_class_sorter
         )
 
+        files_changed = true if html.to_s != code
+
         if write
           File.write(filename, html)
         else
@@ -113,5 +121,6 @@ class ERB::Formatter::CommandLine
         end
       end
     end
+    exit(1) if files_changed && @fail_level == "check"
   end
 end

--- a/test/erb/test_formatter.rb
+++ b/test/erb/test_formatter.rb
@@ -20,6 +20,27 @@ class ERB::TestFormatter < Minitest::Test
     end
   end
 
+  def test_error_on_unformattable_file
+    cli = ERB::Formatter::CommandLine.new(["test/fixtures/unmatched_error.erb"])
+    error = assert_raises RuntimeError do |error|
+      cli.run
+    end
+    assert_match(/Unmatched close tag/, error.message)
+  end
+
+  def test_fail_level_flag_check_with_changes
+    cli = ERB::Formatter::CommandLine.new(["--fail-level", "check", "test/fixtures/attributes.html.erb"])
+    error = assert_raises SystemExit do
+      cli.run
+    end
+    assert_equal(1, error.status)
+  end
+
+  def test_fail_level_flag_check_without_changes
+    cli = ERB::Formatter::CommandLine.new(["--fail-level", "check", "test/fixtures/attributes.html.expected.erb"])
+    cli.run
+  end
+
   def test_format_text_with_extra_long_text
     text = <<~HTML * 30
       Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore

--- a/test/fixtures/unmatched_error.erb
+++ b/test/fixtures/unmatched_error.erb
@@ -1,0 +1,6 @@
+<% if true %>
+  <h1>
+    <%= link_to 'New Order', new_order_path, class: "btn btn-success" %>
+    <% end %>
+  </h1>
+

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,5 +2,6 @@
 
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "erb/formatter"
+require "erb/formatter/command_line"
 
 require "minitest/autorun"


### PR DESCRIPTION
Adds a `--fail-level` flag with 'check' as the only supported option to have a very basic implementation of what was discussed in #17.

Here's an example of it working:
```
$ erb-format --fail-level check test/fixtures/attributes.html.erb
<img
  src="image.jpg"
  alt="Responsive Image"
  srcset="image-480w.jpg 480w, image-800w.jpg 800w, image-1200w.jpg 1200w"
  sizes="(max-width: 600px) 480px, (max-width: 1000px) 800px, 1200px"
  data-autocomplete-min-length-value="2"
  data-short-url="//test.com/?q=v"
  data-long-url="https://google.ca/this-is-a-long-url-with-a-query-string?query=something"
  data-long-url-single='https://google.ca/this-is-a-long-url-with-a-query-string?query=something'
>
$ echo $?
1
```

Fixes #17 