### PR TITLE
Fix order of classes starting with digits in tailwindcss class sorter

### DIFF
--- a/lib/erb/formatter/command_line.rb
+++ b/lib/erb/formatter/command_line.rb
@@ -9,7 +9,7 @@ class ERB::Formatter::CommandLine
     css = css.tr("\n", " ").gsub(%r{\/\*.*?\*\/},"") # remove comments
     css = css.gsub(%r<@media.*?\{>, "") # strip media queries
     css = css.scan(%r<(?:^|\}|\{) *(\S.*?) *\{>).join(" ") # extract selectors
-    classes = css.tr(","," ").split(" ").grep(/\./).uniq.map { _1.split('.').last.gsub("\\", "") }
+    classes = css.tr(","," ").split(" ").grep(/\./).uniq.map { _1.split('.').last.gsub("\\3", "").gsub("\\", "") }
     indexed_classes = Hash[classes.zip((0...classes.size).to_a)]
 
     ->(class_name) do

--- a/test/fixtures/tailwindcss/class_sorting.html.erb
+++ b/test/fixtures/tailwindcss/class_sorting.html.erb
@@ -7,7 +7,7 @@
 <div class="hover:opacity-75 opacity-50 hover:scale-150 scale-125">
 </div>
 
-<div class="lg:grid-cols-4 grid sm:grid-cols-3 grid-cols-2">
+<div class="lg:grid-cols-4 grid 2xl:grid-cols-4 sm:grid-cols-3 grid-cols-2">
 </div>
 
 <div class="p-3 shadow-xl select2-dropdown">

--- a/test/fixtures/tailwindcss/class_sorting.html.expected.erb
+++ b/test/fixtures/tailwindcss/class_sorting.html.expected.erb
@@ -9,7 +9,7 @@
 <div class="scale-125 opacity-50 hover:scale-150 hover:opacity-75">
 </div>
 
-<div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4">
+<div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 2xl:grid-cols-4">
 </div>
 
 <div class="select2-dropdown p-3 shadow-xl">


### PR DESCRIPTION
CSS classes cannot begin with digits. For this reason, Tailwind uses `\3` to escape them. For instance, `2xl:col-span-10` is transformed into `.\32xl\:col-span-10 { grid-column: span 10 / span 10; }` in the final CSS file.

https://github.com/tailwindlabs/tailwindcss/issues/3069

The current Tailwind CSS class sorter implementation does not handle this correctly. As it cannot identify suitable classes beginning with digits, it places them at the start of the sorted list.

Expected output:

    divide-y divide-gray-200 lg:col-span-8 xl:col-span-9 2xl:col-span-10 pb-10

Current output:

    2xl:col-span-10 divide-y divide-gray-200 pb-10 lg:col-span-8 xl:col-span-9

I simply remove the escape characters from the class name.