### PR TITLE
Put unquoted and name only attributes on the same line when possible

### DIFF
--- a/lib/erb/formatter.rb
+++ b/lib/erb/formatter.rb
@@ -141,12 +141,12 @@ class ERB::Formatter
       name, value = attr.split('=', 2)
 
       if value.nil?
-        attr_html << indented("#{name}")
+        attr_html << (within_line_width ? " #{name}" : indented("#{name}"))
         next
       end
 
       if /\A#{UNQUOTED_VALUE}\z/o.match?(value)
-        attr_html << indented("#{name}=\"#{value}\"")
+        attr_html << (within_line_width ? " #{name}=\"#{value}\"" : indented("#{name}=\"#{value}\""))
         next
       end
 

--- a/test/fixtures/attributes.html.erb
+++ b/test/fixtures/attributes.html.erb
@@ -9,3 +9,5 @@
      data-short-url="//test.com/?q=v"
      data-long-url="https://google.ca/this-is-a-long-url-with-a-query-string?query=something"
      data-long-url-single='https://google.ca/this-is-a-long-url-with-a-query-string?query=something'>
+<input type=text class="text-sm" hidden />
+<input name="very-long-name-should-break-because-of-longer-than-width" type=text class="text-sm" hidden />

--- a/test/fixtures/attributes.html.expected.erb
+++ b/test/fixtures/attributes.html.expected.erb
@@ -8,3 +8,10 @@
   data-long-url="https://google.ca/this-is-a-long-url-with-a-query-string?query=something"
   data-long-url-single='https://google.ca/this-is-a-long-url-with-a-query-string?query=something'
 >
+<input type="text" class="text-sm" hidden/>
+<input
+  name="very-long-name-should-break-because-of-longer-than-width"
+  type="text"
+  class="text-sm"
+  hidden
+/>


### PR DESCRIPTION
Currently, unquoted and name-only attributes are placed on a new line, even when they could fit on the same line. This PR modifies this behavior to keep them on the same line when possible.

Expected output:

    <input type="hidden" name="my-name" value="my-value" hidden/>

Current output:

    <input type="hidden" name="my-name" value="my-value"
      hidden/>