### PR TITLE
Update instructions for Zed

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ let g:ale_fixers = {
 With the gem installed, configure `settings.json` to use the formatter as an external command
 
 ```json
-"language_overrides": {
+"languages": {
   "ERB": {
     "formatter": {
       "external": {


### PR DESCRIPTION
The older setting name was removed in https://github.com/zed-industries/zed/pull/13164

cc @LucasKuhn who originally added this in https://github.com/nebulab/erb-formatter/pull/45