### PR TITLE
Add option for not splitting classes onto newlines

### DIFF
--- a/lib/erb/formatter/command_line.rb
+++ b/lib/erb/formatter/command_line.rb
@@ -66,6 +66,10 @@ class ERB::Formatter::CommandLine
         @fail_level = value
       end
 
+      parser.on("--[no-]split-classes", "Split classes on multiple lines") do |value|
+        @split_classes = value
+      end
+
       parser.on("-h", "--help", "Prints this help") do
         puts parser
         exit
@@ -109,7 +113,8 @@ class ERB::Formatter::CommandLine
           filename: filename,
           line_width: @width || 80,
           single_class_per_line: @single_class_per_line,
-          css_class_sorter: css_class_sorter
+          css_class_sorter: css_class_sorter,
+          split_classes: @split_classes
         )
 
         files_changed = true if html.to_s != code

--- a/test/erb/test_formatter.rb
+++ b/test/erb/test_formatter.rb
@@ -202,4 +202,18 @@ class ERB::TestFormatter < Minitest::Test
       ).to_s,
     )
   end
+
+  def test_format_with_no_split_classes
+    assert_equal(
+      "<div\n" \
+      "  class=\"class1 class2 class3 class4 class5 class6 class7 class8 class9 class10 class11 class12 class13 class14 class15\"\n" \
+      ">\n" \
+      "  asdf\n" \
+      "</div>\n",
+      ERB::Formatter.new(
+        "<div class=\"class1 class2 class3 class4 class5 class6 class7 class8 class9 class10 class11 class12 class13 class14 class15\"> asdf </div>",
+        split_classes: false,
+      ).to_s,
+    )
+  end
 end


### PR DESCRIPTION
Splitting classes onto newlines may not mix well with other class sorting libraries that expect them to all be on a single line, this PR adds an option to splitting the class attribute up, while preserving the current behavior as the default.