### PR TITLE
Support case..in in views

### DIFF
--- a/lib/erb/formatter.rb
+++ b/lib/erb/formatter.rb
@@ -63,7 +63,7 @@ class ERB::Formatter
 
   RUBY_STANDALONE_BLOCK = /\A(yield|next)\b/
   RUBY_CLOSE_BLOCK = /\Aend\z/
-  RUBY_REOPEN_BLOCK = /\A(else|elsif\b(.*)|when\b(.*))\z/
+  RUBY_REOPEN_BLOCK = /\A(else|(elsif|when|in)\b(.*))\z/
 
   RUBOCOP_STDIN_MARKER = "===================="
 

--- a/test/fixtures/case_in.html.erb
+++ b/test/fixtures/case_in.html.erb
@@ -1,0 +1,10 @@
+<% case { hash: { nested: '4' } } %>
+        <% in { hash: { nested: } } %>
+  <span>there</span>
+          <% in { another: } %>
+  <span>there</span>
+  <% in { yet_another: { nested: } %>
+         <span>hi</span>
+        <% else %>
+  <span>there</span>
+    <% end %>

--- a/test/fixtures/case_in.html.expected.erb
+++ b/test/fixtures/case_in.html.expected.erb
@@ -1,0 +1,10 @@
+<% case { hash: { nested: '4' } } %>
+<% in { hash: { nested: } } %>
+  <span>there</span>
+<% in { another: } %>
+  <span>there</span>
+<% in { yet_another: { nested: } %>
+  <span>hi</span>
+<% else %>
+  <span>there</span>
+<% end %>


### PR DESCRIPTION
Hello,

`erb-formatter` fails on `case..in` statements in the views, this adds support for that.