### PR TITLE
Add `break` to `RUBY_STANDALONE_BLOCK`

### DIFF
--- a/lib/erb/formatter.rb
+++ b/lib/erb/formatter.rb
@@ -61,7 +61,7 @@ class ERB::Formatter
     end.freeze
   end
 
-  RUBY_STANDALONE_BLOCK = /\A(yield|next)\b/
+  RUBY_STANDALONE_BLOCK = /\A(yield|next|break)\b/
   RUBY_CLOSE_BLOCK = /\Aend\z/
   RUBY_REOPEN_BLOCK = /\A(else|(elsif|when|in)\b(.*))\z/
 


### PR DESCRIPTION
Fix the formatter getting broken if there is a `break` statement in the code.